### PR TITLE
fix: non-unique transfer query

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,9 +16,9 @@ model Transfer {
   resource     Resource?      @relation(fields: [resourceID], references: [id])
   resourceID   String?
   fromDomain   Domain         @relation(name: "fromDomainRelation", fields: [fromDomainId], references: [id])
-  fromDomainId String
+  fromDomainId Int 
   toDomain     Domain?        @relation(name: "toDomainRelation", fields: [toDomainId], references: [id])
-  toDomainId   String?
+  toDomainId   Int?
   sender       String?
   destination  String?
   amount       String?
@@ -28,7 +28,7 @@ model Transfer {
   execution    Execution?
   fee          Fee?
 
-  @@unique(fields: [depositNonce, fromDomainId], name: "nonceDomain")
+  @@unique(fields: [depositNonce, fromDomainId, toDomainId], name: "transferId")
 }
 
 enum TransferStatus {
@@ -44,7 +44,7 @@ model Resource {
 }
 
 model Domain {
-  id   String @id @map("_id")
+  id   Int @id @map("_id")
   name String
 
   lastIndexedBlock String

--- a/src/indexer/repository/domain.ts
+++ b/src/indexer/repository/domain.ts
@@ -5,11 +5,11 @@ class DomainRepository {
   public domain = new PrismaClient().domain
 
   public async insertDomain(domainID: number, latestBlock: string, domainName: string): Promise<void> {
-    const domain = await this.getLastIndexedBlock(domainID.toString())
+    const domain = await this.getLastIndexedBlock(domainID)
     if (!domain) {
       await this.domain.create({
         data: {
-          id: domainID.toString(),
+          id: domainID,
           name: domainName,
           lastIndexedBlock: latestBlock,
         },
@@ -20,7 +20,7 @@ class DomainRepository {
     try {
       await this.domain.update({
         where: {
-          id: domainID.toString(),
+          id: domainID,
         },
         data: {
           lastIndexedBlock: blockNumber,
@@ -31,7 +31,7 @@ class DomainRepository {
     }
   }
 
-  public async getLastIndexedBlock(domainID: string): Promise<Domain | null> {
+  public async getLastIndexedBlock(domainID: number): Promise<Domain | null> {
     return await this.domain.findFirst({
       where: {
         id: domainID,

--- a/src/indexer/services/substrateIndexer/substrateIndexer.ts
+++ b/src/indexer/services/substrateIndexer/substrateIndexer.ts
@@ -45,7 +45,7 @@ export class SubstrateIndexer {
   }
 
   public async listenToEvents(): Promise<void> {
-    const lastIndexedBlock = await this.getLastIndexedBlock(this.domain.id.toString())
+    const lastIndexedBlock = await this.getLastIndexedBlock(this.domain.id)
     let currentBlock = this.domain.startBlock
     if (lastIndexedBlock && lastIndexedBlock > this.domain.startBlock) {
       currentBlock = lastIndexedBlock + 1
@@ -83,7 +83,7 @@ export class SubstrateIndexer {
     }
   }
 
-  private async getLastIndexedBlock(domainID: string): Promise<number> {
+  private async getLastIndexedBlock(domainID: number): Promise<number> {
     const domainRes = await this.domainRepository.getLastIndexedBlock(domainID)
     return domainRes ? Number(domainRes.lastIndexedBlock) : this.domain.startBlock
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Deposits and executions are currently not tied correctly as transfers are search by originDomainID and deposit nonce which is not unique (originDomain 1 depositNonce 1 can be for domain 2 and for domain 3).
Fixed transfer search so it is per route (originDomain 2 destinationDomain 3 depositNonce 1).

## Description
<!--- Describe your changes in detail -->

## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->

Closes: #<issue>

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [ ] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
