### PR TITLE
fix: Added separate timestamps for deposit and execution

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,7 +21,6 @@ model Transfer {
   toDomainId   Int?
   destination  String?
   amount       String?
-  timestamp    DateTime?
   status       TransferStatus
   deposit      Deposit?
   execution    Execution?
@@ -69,6 +68,7 @@ model Deposit {
   txHash          String
   blockNumber     String
   depositData     String
+  timestamp       DateTime
   handlerResponse String
 }
 
@@ -77,6 +77,7 @@ model Execution {
   transfer    Transfer @relation(fields: [transferId], references: [id])
   transferId  String   @unique @db.ObjectId
   txHash      String
+  timestamp   DateTime
   blockNumber String
 }
 

--- a/src/Interfaces/TransfersInterfaces/index.ts
+++ b/src/Interfaces/TransfersInterfaces/index.ts
@@ -77,12 +77,14 @@ export type IncludedQueryParams = {
         blockNumber: boolean
         depositData: boolean
         handlerResponse: boolean
+        timestamp: boolean
       }
     }
     execution: {
       select: {
         txHash: boolean
         blockNumber: boolean
+        timestamp: boolean
       }
     }
     account: {

--- a/src/indexer/repository/transfer.ts
+++ b/src/indexer/repository/transfer.ts
@@ -14,7 +14,6 @@ export type TransferMetadata = {
   fromDomainId: string
   toDomainId: string
   resourceID: string
-  timestamp: Date
   resource: {
     connect: {
       id: string
@@ -61,7 +60,6 @@ class TransferRepository {
           id: Number(decodedLog.toDomainId),
         },
       },
-      timestamp: new Date(decodedLog.timestamp * 1000), // this is only being used by evm service
       usdValue: decodedLog.usdValue,
     }
 
@@ -96,7 +94,7 @@ class TransferRepository {
   public async insertSubstrateDepositTransfer(
     substrateDepositData: Pick<
       DecodedDepositLog,
-      "depositNonce" | "sender" | "amount" | "destination" | "resourceID" | "toDomainId" | "fromDomainId" | "timestamp"
+      "depositNonce" | "sender" | "amount" | "destination" | "resourceID" | "toDomainId" | "fromDomainId"
     > & { usdValue: number },
   ): Promise<Transfer> {
     const transferData = {
@@ -121,7 +119,6 @@ class TransferRepository {
           id: Number(substrateDepositData.toDomainId),
         },
       },
-      timestamp: new Date(substrateDepositData.timestamp),
       account: {
         connect: {
           id: substrateDepositData.sender,
@@ -134,7 +131,7 @@ class TransferRepository {
   }
 
   public async insertExecutionTransfer(
-    { depositNonce, fromDomainId, timestamp }: Pick<DecodedProposalExecutionLog, "depositNonce" | "fromDomainId" | "timestamp">,
+    { depositNonce, fromDomainId }: Pick<DecodedProposalExecutionLog, "depositNonce" | "fromDomainId">,
     toDomainId: number,
   ): Promise<Transfer> {
     const transferData = {
@@ -155,7 +152,6 @@ class TransferRepository {
           id: toDomainId,
         },
       },
-      timestamp: new Date(timestamp),
     } as unknown as Transfer
 
     return await this.transfer.create({ data: transferData })
@@ -192,10 +188,9 @@ class TransferRepository {
       resourceID,
       fromDomainId,
       toDomainId,
-      timestamp,
       sender,
       usdValue,
-    }: Pick<DecodedDepositLog, "depositNonce" | "sender" | "amount" | "destination" | "resourceID" | "fromDomainId" | "toDomainId" | "timestamp"> & {
+    }: Pick<DecodedDepositLog, "depositNonce" | "sender" | "amount" | "destination" | "resourceID" | "fromDomainId" | "toDomainId"> & {
       usdValue: number | null
     },
     id: string,
@@ -224,9 +219,8 @@ class TransferRepository {
           id: sender,
         },
       },
-      timestamp: new Date(timestamp),
       usdValue: usdValue,
-    } as Pick<TransferMetadata, "depositNonce" | "amount" | "destination" | "resource" | "fromDomain" | "toDomain" | "account" | "timestamp">
+    } as Pick<TransferMetadata, "depositNonce" | "amount" | "destination" | "resource" | "fromDomain" | "toDomain" | "account">
     return await this.transfer.update({ where: { id: id }, data: transferData })
   }
 

--- a/src/indexer/services/evmIndexer/evmTypes.ts
+++ b/src/indexer/services/evmIndexer/evmTypes.ts
@@ -41,6 +41,7 @@ export type DecodedFailedHandlerExecution = {
   message: string
   txHash: string
   blockNumber: number
+  timestamp: number
 }
 
 export type DecodedFeeCollectedLog = {

--- a/src/indexer/utils/evm/index.ts
+++ b/src/indexer/utils/evm/index.ts
@@ -204,7 +204,7 @@ export function parseFailedHandlerExecution(log: Log, decodedLog: LogDescription
     txHash: log.transactionHash,
     message: ethers.decodeBytes32String("0x" + Buffer.from(errorData.slice(-64)).toString()),
     blockNumber: log.blockNumber,
-    timestamp: blockUnixTimestamp
+    timestamp: blockUnixTimestamp,
   }
 }
 
@@ -282,7 +282,6 @@ export async function saveDepositLogs(
   } else {
     const dataToSave = {
       ...decodedLog,
-      timestamp: decodedLog.timestamp * 1000,
       usdValue: amountInUSD,
     }
     await transferRepository.updateTransfer(dataToSave, transfer.id)
@@ -323,7 +322,6 @@ export async function saveProposalExecutionLogs(
   if (!transfer) {
     const dataToInsert = {
       ...decodedLog,
-      timestamp: decodedLog.timestamp * 1000,
     }
     transfer = await transferRepository.insertExecutionTransfer(dataToInsert, toDomainId)
   } else {
@@ -334,7 +332,7 @@ export async function saveProposalExecutionLogs(
     id: new ObjectId().toString(),
     transferId: transfer.id,
     txHash: decodedLog.txHash,
-    timestamp: new Date(decodedLog.timestamp*1000),
+    timestamp: new Date(decodedLog.timestamp * 1000),
     blockNumber: decodedLog.blockNumber.toString(),
   }
   await executionRepository.insertExecution(execution)
@@ -357,7 +355,7 @@ export async function saveFailedHandlerExecutionLogs(
     id: new ObjectId().toString(),
     transferId: transfer.id,
     txHash: error.txHash,
-    timestamp: new Date(error.timestamp*1000),
+    timestamp: new Date(error.timestamp * 1000),
     blockNumber: error.blockNumber.toString(),
   }
   await executionRepository.insertExecution(execution)

--- a/src/indexer/utils/evm/index.ts
+++ b/src/indexer/utils/evm/index.ts
@@ -88,7 +88,7 @@ export async function getDecodedLogs(
     }
 
     case EventType.FAILED_HANDLER_EXECUTION: {
-      const errorData = parseFailedHandlerExecution(log, decodedLog)
+      const errorData = parseFailedHandlerExecution(log, decodedLog, blockUnixTimestamp)
       decodedLogs.errors.push(errorData)
       break
     }
@@ -195,7 +195,7 @@ export async function parseFeeCollected(
   }
 }
 
-export function parseFailedHandlerExecution(log: Log, decodedLog: LogDescription): DecodedFailedHandlerExecution {
+export function parseFailedHandlerExecution(log: Log, decodedLog: LogDescription, blockUnixTimestamp: number): DecodedFailedHandlerExecution {
   const originDomainID = decodedLog.args.originDomainID as number
   const errorData = decodedLog.args.lowLevelData as ArrayBuffer
   return {
@@ -204,6 +204,7 @@ export function parseFailedHandlerExecution(log: Log, decodedLog: LogDescription
     txHash: log.transactionHash,
     message: ethers.decodeBytes32String("0x" + Buffer.from(errorData.slice(-64)).toString()),
     blockNumber: log.blockNumber,
+    timestamp: blockUnixTimestamp
   }
 }
 
@@ -293,6 +294,7 @@ export async function saveDepositLogs(
     txHash: decodedLog.txHash,
     blockNumber: decodedLog.blockNumber.toString(),
     depositData: decodedLog.depositData,
+    timestamp: new Date(decodedLog.timestamp * 1000),
     handlerResponse: decodedLog.handlerResponse,
     transferId: transfer.id,
   }
@@ -332,6 +334,7 @@ export async function saveProposalExecutionLogs(
     id: new ObjectId().toString(),
     transferId: transfer.id,
     txHash: decodedLog.txHash,
+    timestamp: new Date(decodedLog.timestamp*1000),
     blockNumber: decodedLog.blockNumber.toString(),
   }
   await executionRepository.insertExecution(execution)
@@ -354,6 +357,7 @@ export async function saveFailedHandlerExecutionLogs(
     id: new ObjectId().toString(),
     transferId: transfer.id,
     txHash: error.txHash,
+    timestamp: new Date(error.timestamp*1000),
     blockNumber: error.blockNumber.toString(),
   }
   await executionRepository.insertExecution(execution)

--- a/src/indexer/utils/substrate/index.ts
+++ b/src/indexer/utils/substrate/index.ts
@@ -47,7 +47,6 @@ export async function saveProposalExecution(
       {
         depositNonce: Number(depositNonce),
         fromDomainId: originDomainId,
-        timestamp,
       },
       toDomainId,
     )

--- a/src/indexer/utils/substrate/index.ts
+++ b/src/indexer/utils/substrate/index.ts
@@ -59,6 +59,7 @@ export async function saveProposalExecution(
     id: new ObjectId().toString(),
     transferId: transfer.id,
     txHash: txIdentifier,
+    timestamp: new Date(timestamp),
     blockNumber: blockNumber,
   }
   await executionRepository.insertExecution(execution)
@@ -70,7 +71,7 @@ export async function saveFailedHandlerExecution(
   executionRepository: ExecutionRepository,
   transferRepository: TransferRepository,
 ): Promise<void> {
-  const { originDomainId, depositNonce, txIdentifier, blockNumber, error } = failedHandlerExecutionData
+  const { originDomainId, depositNonce, txIdentifier, blockNumber, error, timestamp } = failedHandlerExecutionData
 
   let transfer = await transferRepository.findTransfer(Number(depositNonce), Number(originDomainId), toDomainId)
   // there is no transfer yet, but a proposal execution exists
@@ -91,6 +92,7 @@ export async function saveFailedHandlerExecution(
     id: new ObjectId().toString(),
     transferId: transfer.id,
     txHash: txIdentifier,
+    timestamp: new Date(timestamp),
     blockNumber: blockNumber,
   }
   await executionRepository.insertExecution(execution)
@@ -192,6 +194,7 @@ export async function saveDeposit(
     txHash: txIdentifier,
     blockNumber: blockNumber,
     depositData: depositData,
+    timestamp: new Date(timestamp),
     handlerResponse: handlerResponse,
     transferId: transfer.id,
   }

--- a/src/services/transfers.service.ts
+++ b/src/services/transfers.service.ts
@@ -40,6 +40,11 @@ class TransfersService {
       where,
       take,
       skip,
+      orderBy: {
+        deposit: {
+          timestamp: "desc",
+        },
+      },
       include: {
         ...getTransferQueryParams().include,
       },

--- a/src/services/transfers.service.ts
+++ b/src/services/transfers.service.ts
@@ -40,11 +40,6 @@ class TransfersService {
       where,
       take,
       skip,
-      orderBy: [
-        {
-          timestamp: "desc",
-        },
-      ],
       include: {
         ...getTransferQueryParams().include,
       },

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -68,12 +68,14 @@ export const getTransferQueryParams = (): IncludedQueryParams => {
           blockNumber: true,
           depositData: true,
           handlerResponse: true,
+          timestamp: true,
         },
       },
       execution: {
         select: {
           txHash: true,
           blockNumber: true,
+          timestamp: true,
         },
       },
       account: {

--- a/tests/e2e/domainAndResourceRoute.spec.ts
+++ b/tests/e2e/domainAndResourceRoute.spec.ts
@@ -76,7 +76,6 @@ describe("Get all transfers for a specific resource between source and destinati
         toDomainId: 2,
         destination: "0x8e0a907331554af72563bd8d43051c2e64be5d35",
         amount: "2296080355773541392",
-        timestamp: "2023-07-17T08:31:22.000Z",
         status: "executed",
         accountId: "0x5C1F5961696BaD2e73f73417f07EF55C62a2dC5b",
         message: "",
@@ -98,10 +97,12 @@ describe("Get all transfers for a specific resource between source and destinati
           depositData:
             "0x0000000000000000000000000000000000000000000000001fdd50eb1da26c1000000000000000000000000000000000000000000000000000000000000000148e0a907331554af72563bd8d43051c2e64be5d35000000000000000000000000000000000000000000000000000000000000000c6d657461646174612e75726c",
           handlerResponse: "0x6d657461646174612e746573746d657461646174612e75726c",
+          timestamp: "2023-07-17T08:31:22.000Z",
         },
         execution: {
           txHash: "0x3de2201e548a8332aaa50147a2fb02e2b6669184f042b4dbcf23b4f5d40edcfb",
           blockNumber: "598",
+          timestamp: "2023-07-17T08:31:35.000Z",
         },
         account: { addressStatus: "" },
       },
@@ -127,7 +128,6 @@ describe("Get all transfers for a specific resource between source and destinati
         destination:
           "0x696bad2e73f73417f07ef55c62a2dc5b47ed248f568cc8f9fe4371a1d1fab88a62af595f8efb9aeff6f0e043b7ea33b10000000000000000000000005c1f5961696bad2e73f73417f07ef55c62a2dc5b",
         amount: "",
-        timestamp: "2023-07-17T08:32:27.000Z",
         status: "executed",
         accountId: "0x5C1F5961696BaD2e73f73417f07EF55C62a2dC5b",
         message: "",
@@ -149,10 +149,12 @@ describe("Get all transfers for a specific resource between source and destinati
           depositData:
             "0x0000000000000000000000000000000000000000000000000000000000030d400004ea287d1514b1387b365ae7294ea13bad9db83436e671dd16ba145c1f5961696bad2e73f73417f07ef55c62a2dc5b47ed248f568cc8f9fe4371a1d1fab88a62af595f8efb9aeff6f0e043b7ea33b10000000000000000000000005c1f5961696bad2e73f73417f07ef55c62a2dc5b",
           handlerResponse: "0x",
+          timestamp: "2023-07-17T08:32:27.000Z",
         },
         execution: {
           txHash: "0xcc7c318cfd71745c27111772f21dec553f53277c9dc218fe07b54f897560c0cb",
           blockNumber: "631",
+          timestamp: "2023-07-17T08:32:42.000Z",
         },
         account: { addressStatus: "" },
       },

--- a/tests/e2e/indexing.spec.ts
+++ b/tests/e2e/indexing.spec.ts
@@ -100,15 +100,17 @@ describe("Indexer e2e tests", function () {
       expect(transfer.resource).to.be.not.null
       expect(transfer.resourceID).to.be.not.null
       expect(transfer.accountId).to.be.not.null
-      expect(transfer.timestamp).to.be.not.null
       expect(transfer.toDomain).to.be.not.null
       expect(transfer.toDomainId).to.be.not.null
       expect(transfer.execution).to.be.not.null
+      expect(transfer.deposit.timestamp).to.be.not.null
+      expect(transfer.execution.timestamp).to.be.not.null
     })
   })
   it("should succesfully fetch evm fungible transfer", async () => {
     const res = await axios.get(`http://localhost:8000/api/transfers/txHash/${FUNGIBLE_EVM_DEPOSIT_TXHASH}?`)
     const transfer = res.data as TransferResponse
+
     expect(transfer).to.be.deep.equal({
       id: transfer.id,
       message: "",
@@ -119,7 +121,6 @@ describe("Indexer e2e tests", function () {
       accountId: "0x5C1F5961696BaD2e73f73417f07EF55C62a2dC5b",
       destination: "0x8e0a907331554af72563bd8d43051c2e64be5d35",
       amount: "0.0000000000000001",
-      timestamp: "2023-07-17T08:32:37.000Z",
       status: "executed",
       resource: {
         type: "fungible",
@@ -138,10 +139,12 @@ describe("Indexer e2e tests", function () {
         depositData:
           "0x000000000000000000000000000000000000000000000000000000000000006400000000000000000000000000000000000000000000000000000000000000148e0a907331554af72563bd8d43051c2e64be5d350102",
         handlerResponse: "0x",
+        timestamp: "2023-07-17T08:32:37.000Z",
       },
       execution: {
         txHash: "0xb8de40d5d0f5eb8ac4d2a54858bcd4946c85dfcb4353710df1cb73cc6b030c10",
         blockNumber: "643",
+        timestamp: "2023-07-17T08:33:06.000Z",
       },
       account: {
         addressStatus: "",
@@ -153,6 +156,7 @@ describe("Indexer e2e tests", function () {
   it("should succesfully fetch evm nonfungible transfer", async () => {
     const res = await axios.get(`http://localhost:8000/api/transfers/txHash/${NONFUNGIBLE_EVM_DEPOSIT_TXHASH}?`)
     const transfer = res.data as TransferResponse
+
     expect(transfer).to.be.deep.equal({
       id: transfer.id,
       depositNonce: 2,
@@ -163,7 +167,6 @@ describe("Indexer e2e tests", function () {
       accountId: "0x5C1F5961696BaD2e73f73417f07EF55C62a2dC5b",
       destination: "0x8e0a907331554af72563bd8d43051c2e64be5d35",
       amount: "2296080355773541392",
-      timestamp: "2023-07-17T08:31:22.000Z",
       status: "executed",
       resource: {
         type: "nonfungible",
@@ -182,10 +185,12 @@ describe("Indexer e2e tests", function () {
         depositData:
           "0x0000000000000000000000000000000000000000000000001fdd50eb1da26c1000000000000000000000000000000000000000000000000000000000000000148e0a907331554af72563bd8d43051c2e64be5d35000000000000000000000000000000000000000000000000000000000000000c6d657461646174612e75726c",
         handlerResponse: "0x6d657461646174612e746573746d657461646174612e75726c",
+        timestamp: "2023-07-17T08:31:22.000Z",
       },
       execution: {
         txHash: "0x3de2201e548a8332aaa50147a2fb02e2b6669184f042b4dbcf23b4f5d40edcfb",
         blockNumber: "598",
+        timestamp: "2023-07-17T08:31:35.000Z",
       },
       account: {
         addressStatus: "",
@@ -197,6 +202,7 @@ describe("Indexer e2e tests", function () {
   it("should succesfully fetch evm permissionless generic transfer", async () => {
     const res = await axios.get(`http://localhost:8000/api/transfers/txHash/${PERMISSIONLESS_GENERIC_EVM_DEPOSIT_TXHASH}?`)
     const transfer = res.data as TransferResponse
+
     expect(transfer).to.be.deep.equal({
       id: transfer.id,
       depositNonce: 29,
@@ -208,7 +214,6 @@ describe("Indexer e2e tests", function () {
       destination:
         "0x696bad2e73f73417f07ef55c62a2dc5b47ed248f568cc8f9fe4371a1d1fab88a62af595f8efb9aeff6f0e043b7ea33b10000000000000000000000005c1f5961696bad2e73f73417f07ef55c62a2dc5b",
       amount: "",
-      timestamp: "2023-07-17T08:32:27.000Z",
       status: "executed",
       resource: {
         type: "permissionlessGeneric",
@@ -227,10 +232,12 @@ describe("Indexer e2e tests", function () {
         depositData:
           "0x0000000000000000000000000000000000000000000000000000000000030d400004ea287d1514b1387b365ae7294ea13bad9db83436e671dd16ba145c1f5961696bad2e73f73417f07ef55c62a2dc5b47ed248f568cc8f9fe4371a1d1fab88a62af595f8efb9aeff6f0e043b7ea33b10000000000000000000000005c1f5961696bad2e73f73417f07ef55c62a2dc5b",
         handlerResponse: "0x",
+        timestamp: "2023-07-17T08:32:27.000Z",
       },
       execution: {
         txHash: "0xcc7c318cfd71745c27111772f21dec553f53277c9dc218fe07b54f897560c0cb",
         blockNumber: "631",
+        timestamp: "2023-07-17T08:32:42.000Z",
       },
       account: {
         addressStatus: "",
@@ -242,6 +249,7 @@ describe("Indexer e2e tests", function () {
   it("should succesfully fetch evm permissioned generic transfer", async () => {
     const res = await axios.get(`http://localhost:8000/api/transfers/txHash/${PERMISSIONED_GENERIC_EVM_DEPOSIT_TXHASH}?`)
     const transfer = res.data as TransferResponse
+
     expect(transfer).to.be.deep.equal({
       id: transfer.id,
       depositNonce: 3,
@@ -252,7 +260,6 @@ describe("Indexer e2e tests", function () {
       destination: "0x",
       message: "",
       amount: "",
-      timestamp: "2023-07-17T08:31:36.000Z",
       status: "executed",
       resource: {
         type: "permissionedGeneric",
@@ -271,10 +278,12 @@ describe("Indexer e2e tests", function () {
         depositData:
           "0x000000000000000000000000000000000000000000000000000000000000002030bb0f28498d8bc6272403413a967b2098aa4d7c7422d4ff2ff2c6c2bdc44af3",
         handlerResponse: "0x",
+        timestamp: "2023-07-17T08:31:36.000Z",
       },
       execution: {
         txHash: "0xf031174a3a2b3ae7064f2ca083fa35b1b48b7723ae45ce1f925c9c09a3ba3077",
         blockNumber: "603",
+        timestamp: "2023-07-17T08:31:45.000Z",
       },
       account: {
         addressStatus: "",
@@ -286,6 +295,7 @@ describe("Indexer e2e tests", function () {
   it("should succesfully fetch substrate to evm fungible transfer", async () => {
     const res = await axios.get(`http://localhost:8000/api/transfers/txHash/${FUNGIBLE_SUBSTRATE_TO_EVM_DEPOSIT_TXHASH}?`)
     const transfer = res.data as TransferResponse
+
     expect(transfer).to.be.deep.equal({
       id: transfer.id,
       depositNonce: 2,
@@ -296,7 +306,6 @@ describe("Indexer e2e tests", function () {
       accountId: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
       destination: "0x5c1f5961696bad2e73f73417f07ef55c62a2dc5b",
       amount: "0.000000000001",
-      timestamp: "2023-07-17T08:29:12.000Z",
       status: "executed",
       resource: {
         type: "fungible",
@@ -311,10 +320,12 @@ describe("Indexer e2e tests", function () {
         depositData:
           "0x00000000000000000000000000000000000000000000000000000000000f424000000000000000000000000000000000000000000000000000000000000000145c1f5961696bad2e73f73417f07ef55c62a2dc5b",
         handlerResponse: "",
+        timestamp: "2023-07-17T08:29:12.000Z",
       },
       execution: {
         txHash: "0xe5648eb14c885ddf52226aea17440ec3126bfff778c70e0a366dc9666301ff35",
         blockNumber: "548",
+        timestamp: "2023-07-17T08:29:55.000Z",
       },
       account: {
         addressStatus: "",
@@ -326,6 +337,7 @@ describe("Indexer e2e tests", function () {
   it("should succesfully fetch evm to substrate fungible transfer", async () => {
     const res = await axios.get(`http://localhost:8000/api/transfers/txHash/${FUNGIBLE_EVM_TO_SUBSTRATE_DEPOSIT}?`)
     const transfer = res.data as TransferResponse
+
     expect(transfer).to.be.deep.equal({
       id: transfer.id,
       depositNonce: 2,
@@ -336,7 +348,6 @@ describe("Indexer e2e tests", function () {
       accountId: "0x5C1F5961696BaD2e73f73417f07EF55C62a2dC5b",
       destination: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
       amount: "0.0001",
-      timestamp: "2023-07-17T08:28:51.000Z",
       status: "executed",
       resource: {
         type: "fungible",
@@ -355,8 +366,13 @@ describe("Indexer e2e tests", function () {
         depositData:
           "0x00000000000000000000000000000000000000000000000000005af3107a4000000000000000000000000000000000000000000000000000000000000000002400010100d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
         handlerResponse: "0x",
+        timestamp: "2023-07-17T08:28:51.000Z",
       },
-      execution: { txHash: "355-1", blockNumber: "355" },
+      execution: {
+        txHash: "355-1",
+        blockNumber: "355",
+        timestamp: "2023-07-17T08:29:06.001Z",
+      },
       account: {
         addressStatus: "",
       },

--- a/tests/e2e/resourceRoute.spec.ts
+++ b/tests/e2e/resourceRoute.spec.ts
@@ -85,7 +85,6 @@ describe("Get all transfers for a specific resource", function () {
         toDomainId: 2,
         destination: "0x8e0a907331554af72563bd8d43051c2e64be5d35",
         amount: "2296080355773541392",
-        timestamp: "2023-07-17T08:31:22.000Z",
         status: "executed",
         accountId: "0x5C1F5961696BaD2e73f73417f07EF55C62a2dC5b",
         message: "",
@@ -107,10 +106,12 @@ describe("Get all transfers for a specific resource", function () {
           depositData:
             "0x0000000000000000000000000000000000000000000000001fdd50eb1da26c1000000000000000000000000000000000000000000000000000000000000000148e0a907331554af72563bd8d43051c2e64be5d35000000000000000000000000000000000000000000000000000000000000000c6d657461646174612e75726c",
           handlerResponse: "0x6d657461646174612e746573746d657461646174612e75726c",
+          timestamp: "2023-07-17T08:31:22.000Z",
         },
         execution: {
           txHash: "0x3de2201e548a8332aaa50147a2fb02e2b6669184f042b4dbcf23b4f5d40edcfb",
           blockNumber: "598",
+          timestamp: "2023-07-17T08:31:35.000Z",
         },
         account: { addressStatus: "" },
       },
@@ -134,7 +135,6 @@ describe("Get all transfers for a specific resource", function () {
         destination:
           "0x696bad2e73f73417f07ef55c62a2dc5b47ed248f568cc8f9fe4371a1d1fab88a62af595f8efb9aeff6f0e043b7ea33b10000000000000000000000005c1f5961696bad2e73f73417f07ef55c62a2dc5b",
         amount: "",
-        timestamp: "2023-07-17T08:32:27.000Z",
         status: "executed",
         accountId: "0x5C1F5961696BaD2e73f73417f07EF55C62a2dC5b",
         message: "",
@@ -156,10 +156,12 @@ describe("Get all transfers for a specific resource", function () {
           depositData:
             "0x0000000000000000000000000000000000000000000000000000000000030d400004ea287d1514b1387b365ae7294ea13bad9db83436e671dd16ba145c1f5961696bad2e73f73417f07ef55c62a2dc5b47ed248f568cc8f9fe4371a1d1fab88a62af595f8efb9aeff6f0e043b7ea33b10000000000000000000000005c1f5961696bad2e73f73417f07ef55c62a2dc5b",
           handlerResponse: "0x",
+          timestamp: "2023-07-17T08:32:27.000Z",
         },
         execution: {
           txHash: "0xcc7c318cfd71745c27111772f21dec553f53277c9dc218fe07b54f897560c0cb",
           blockNumber: "631",
+          timestamp: "2023-07-17T08:32:42.000Z",
         },
         account: { addressStatus: "" },
       },
@@ -182,7 +184,6 @@ describe("Get all transfers for a specific resource", function () {
         toDomainId: 2,
         destination: "0x",
         amount: "",
-        timestamp: "2023-07-17T08:31:36.000Z",
         status: "executed",
         accountId: "0x5C1F5961696BaD2e73f73417f07EF55C62a2dC5b",
         message: "",
@@ -204,10 +205,12 @@ describe("Get all transfers for a specific resource", function () {
           depositData:
             "0x000000000000000000000000000000000000000000000000000000000000002030bb0f28498d8bc6272403413a967b2098aa4d7c7422d4ff2ff2c6c2bdc44af3",
           handlerResponse: "0x",
+          timestamp: "2023-07-17T08:31:36.000Z",
         },
         execution: {
           txHash: "0xf031174a3a2b3ae7064f2ca083fa35b1b48b7723ae45ce1f925c9c09a3ba3077",
           blockNumber: "603",
+          timestamp: "2023-07-17T08:31:45.000Z",
         },
         account: { addressStatus: "" },
       },


### PR DESCRIPTION
Timestamp of deposit and timestamp of execution are now two separate entries in the database. After updating the database, I've refactored the code and tests to function properly. 

closes: #112 
