### PR TITLE
fix: Retrying failed requests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,8 @@ services:
       DATABASE_URL: mongodb://mongo1:30001/sygmaprotocol-explorer-indexer?replicaSet=my-replica-set&authSource=admin&retryWrites=true&w=majority
       SHARED_CONFIG_URL: https://ipfs.io/ipfs/QmW9RhxFFotHtvsU2PMVYU2NNZigeCpbg1ywDCZ3vX675b
       RPC_URL_CONFIG: '[{"id": 1, "endpoint": "http://evm1:8545"}, {"id": 2, "endpoint": "http://evm2:8545"}, {"id": 3, "endpoint": "ws://substrate-pallet:9944"}]'
+      RETRY_COUNT: '1'
+      BACKOFF: '100'
 
   api:
     build: 

--- a/src/indexer/services/coinmarketcap/coinmarketcap.service.ts
+++ b/src/indexer/services/coinmarketcap/coinmarketcap.service.ts
@@ -3,7 +3,7 @@ The Licensed Work is (c) 2023 Sygma
 SPDX-License-Identifier: LGPL-3.0-only
 */
 
-import { fetchRetry } from "utils/helpers"
+import { fetchRetry } from "../../../utils/helpers"
 import { logger } from "../../../utils/logger"
 
 export type CoinMaketCapResponse = {

--- a/src/indexer/services/coinmarketcap/coinmarketcap.service.ts
+++ b/src/indexer/services/coinmarketcap/coinmarketcap.service.ts
@@ -2,6 +2,10 @@
 The Licensed Work is (c) 2023 Sygma
 SPDX-License-Identifier: LGPL-3.0-only
 */
+
+import { fetchRetry } from "utils/helpers"
+import { logger } from "../../../utils/logger"
+
 export type CoinMaketCapResponse = {
   id: number
   symbol: string
@@ -26,18 +30,19 @@ class CoinMarketCapService {
   }
 
   private async getValueConvertion(amount: string, tokenSymbol: string): Promise<CoinMaketCapResponse["quote"]["USD"]["price"]> {
-    const url = `${this.coinMarketCapUrl}/v1/tools/price-conversion?amount=${amount}&symbol=${tokenSymbol}&convert=USD`
+    const url = `${this.coinMarketCapUrl}/v2/tools/price-conversion?amount=${amount}&symbol=${tokenSymbol}&convert=USD`
 
     try {
-      const response = await fetch(url, {
+      const response = await fetchRetry(url, {
         method: "GET",
         headers: {
           "X-CMC_PRO_API_KEY": this.coinMarketCapAPIKey,
         },
       })
-      const { data } = (await response.json()) as { data: CoinMaketCapResponse }
-      return data.quote.USD.price
-    } catch {
+      const { data } = (await response.json()) as { data: CoinMaketCapResponse[] }
+      return data[0].quote.USD.price
+    } catch (err) {
+      logger.error(err)
       throw new Error("Error getting value from CoinMarketCap")
     }
   }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -4,7 +4,7 @@ SPDX-License-Identifier: LGPL-3.0-only
 */
 import { Signer, ethers, AbiCoder } from "ethers"
 import { ERC20Handler__factory as Erc20HandlerFactory, ERC721Handler__factory as Erc721HandlerFactory } from "@buildwithsygma/sygma-contracts"
-import { sleep } from "indexer/utils/substrate"
+import { sleep } from "../indexer/utils/substrate"
 import { EvmBridgeConfig, HandlersMap, SygmaConfig } from "../sygmaTypes"
 import { IncludedQueryParams } from "../Interfaces"
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: LGPL-3.0-only
 */
 import { Signer, ethers, AbiCoder } from "ethers"
 import { ERC20Handler__factory as Erc20HandlerFactory, ERC721Handler__factory as Erc721HandlerFactory } from "@buildwithsygma/sygma-contracts"
+import { sleep } from "indexer/utils/substrate"
 import { EvmBridgeConfig, HandlersMap, SygmaConfig } from "../sygmaTypes"
 import { IncludedQueryParams } from "../Interfaces"
 
@@ -89,4 +90,18 @@ export class NotFound extends Error {
   constructor(message: string) {
     super(message)
   }
+}
+
+export async function fetchRetry(input: RequestInfo | URL, init?: RequestInit | undefined, retryCount = 3, backoff = 500): Promise<Response> {
+  while (retryCount > 0) {
+    try {
+      return await fetch(input, init)
+    } catch (err) {
+      await sleep(backoff)
+      backoff *= 2
+    } finally {
+      retryCount -= 1
+    }
+  }
+  throw new Error(`Error while fetching URL`)
 }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -92,7 +92,12 @@ export class NotFound extends Error {
   }
 }
 
-export async function fetchRetry(input: RequestInfo | URL, init?: RequestInit | undefined, retryCount = 3, backoff = 500): Promise<Response> {
+export async function fetchRetry(
+  input: RequestInfo | URL,
+  init?: RequestInit | undefined,
+  retryCount = parseInt(process.env.RETRY_COUNT || "3"),
+  backoff = parseInt(process.env.BACKOFF || "500"),
+): Promise<Response> {
   while (retryCount > 0) {
     try {
       return await fetch(input, init)


### PR DESCRIPTION
Created an util function `fetchRetry` that retries failed requests with an exponential backoff. Said function is used in CoinMarketCap service. 

closes #123 