### PR TITLE
fix: fetching twice the same deposit event

### DIFF
--- a/src/indexer/services/evmIndexer/evmIndexer.ts
+++ b/src/indexer/services/evmIndexer/evmIndexer.ts
@@ -103,9 +103,9 @@ export class EvmIndexer {
         }
         this.logger.debug(`Indexing block ${currentBlock}`)
         await this.saveEvents(currentBlock, currentBlock + queryInterval)
-        await this.domainRepository.updateBlock(currentBlock.toString(), this.domain.id)
+        await this.domainRepository.updateBlock((currentBlock + queryInterval).toString(), this.domain.id)
 
-        currentBlock += queryInterval
+        currentBlock += queryInterval + 1
       } catch (error) {
         this.logger.error(`Failed to process events for block ${currentBlock}:`, error)
         await sleep(BLOCK_TIME)


### PR DESCRIPTION
fix fetching twice the same deposit event
## Description
Indexer is storing duplicate deposits because of overlap in fetching block events

## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->

Closes: #128 

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [ ] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
