### PR TITLE
fix: Fixed fetchRetry function

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -100,15 +100,21 @@ export async function fetchRetry(
   retryCount = parseInt(process.env.RETRY_COUNT || "3"),
   backoff = parseInt(process.env.BACKOFF || "500"),
 ): Promise<Response> {
+  let statusCode = 0
   while (retryCount > 0) {
     try {
-      return await fetch(input, init)
-    } catch (err) {
+      const res = await fetch(input, init)
+      if (res.status != 200) {
+        statusCode = res.status
+        throw new Error()
+      }
+      return res
+    } catch {
       await sleep(backoff)
       backoff *= 2
     } finally {
       retryCount -= 1
     }
   }
-  throw new Error(`Error while fetching URL`)
+  throw new Error(`Error while fetching URL ${input.toString()}. Status code: ${statusCode}`)
 }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -116,5 +116,5 @@ export async function fetchRetry(
       retryCount -= 1
     }
   }
-  throw new Error(`Error while fetching URL ${input.toString()}. Status code: ${statusCode}`)
+  throw new Error(`Error while fetching URL: ${input.toString()}. Status code: ${statusCode}`)
 }

--- a/tests/unit/fetchRetry.spec.ts
+++ b/tests/unit/fetchRetry.spec.ts
@@ -1,7 +1,11 @@
+/*
+The Licensed Work is (c) 2023 Sygma
+SPDX-License-Identifier: LGPL-3.0-only
+*/
 import { expect } from "chai"
 import { fetchRetry } from "../../src/utils/helpers"
 
-describe("Retrying failed requests testing", function () {
+describe("Failed requests retry testing", function () {
   it("Should successfully fetch", async () => {
     const res = await fetchRetry("https://google.com", {}, 1, 100)
     expect(res.status).to.be.deep.equal(200)

--- a/tests/unit/fetchRetry.spec.ts
+++ b/tests/unit/fetchRetry.spec.ts
@@ -16,6 +16,9 @@ describe("Failed requests retry testing", function () {
       await fetchRetry("https://invalid-url", {}, 1, 100)
     } catch (err) {
       expect(err).to.be.not.null
+      if (err instanceof Error) {
+        expect(err.message).to.be.equal("Error while fetching URL: https://invalid-url. Status code: 0")
+      }
     }
   })
 })

--- a/tests/unit/fetchRetry.spec.ts
+++ b/tests/unit/fetchRetry.spec.ts
@@ -1,0 +1,17 @@
+import { expect } from "chai"
+import { fetchRetry } from "../../src/utils/helpers"
+
+describe("Retrying failed requests testing", function () {
+  it("Should successfully fetch", async () => {
+    const res = await fetchRetry("https://google.com", {}, 1, 100)
+    expect(res.status).to.be.deep.equal(200)
+  })
+
+  it("Should fail because of invalid request", async () => {
+    try {
+      await fetchRetry("https://invalid-url", {}, 1, 100)
+    } catch (err) {
+      expect(err).to.be.not.null
+    }
+  })
+})


### PR DESCRIPTION
Noticed that `fetch()` function only throws an error when a network error is encountered (which is usually when there's a permissions issue or similar). Fixed `fetchRetry()` so that `fetch()` is retried also when HTTP errors (4xx, 5xx etc.) are encountered. 
Also, added unit testing for `fetchRetry()`. 