### PR TITLE
chore: workflows for slack notification

### DIFF
--- a/.github/workflows/deploy_mainnet.yml
+++ b/.github/workflows/deploy_mainnet.yml
@@ -68,6 +68,15 @@ jobs:
          cluster: sygma-explorer-${{ env.ENVIRONMENT }}
          wait-for-service-stability: true
 
+     - name: slack notify
+       uses: 8398a7/action-slack@v3
+       with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,job,eventName,ref,workflow # selectable (default: repo,message)
+       env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+       if: always()
+
   deploy_v2:
    name: deploy v2
   
@@ -117,3 +126,12 @@ jobs:
          service: explorer-indexer-service-v2-${{ env.ENVIRONMENT }}
          cluster: sygma-explorer-${{ env.ENVIRONMENT }}
          wait-for-service-stability: true
+
+     - name: slack notify
+       uses: 8398a7/action-slack@v3
+       with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,job,eventName,ref,workflow # selectable (default: repo,message)
+       env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+       if: always()

--- a/.github/workflows/deploy_mainnet_api.yml
+++ b/.github/workflows/deploy_mainnet_api.yml
@@ -64,3 +64,12 @@ jobs:
          service: explorer-api-service-${{ env.ENVIRONMENT }}
          cluster: sygma-explorer-${{ env.ENVIRONMENT }}
          wait-for-service-stability: true
+
+     - name: slack notify
+       uses: 8398a7/action-slack@v3
+       with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,job,eventName,ref,workflow # selectable (default: repo,message)
+       env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+       if: always()

--- a/.github/workflows/deploy_testnet.yml
+++ b/.github/workflows/deploy_testnet.yml
@@ -52,7 +52,15 @@ jobs:
           context: .
           push: true
           tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.ref_name }}
-          
+
+      - name: slack notify
+        uses: 8398a7/action-slack@v3
+        with:
+            status: ${{ job.status }}
+            fields: repo,message,commit,author,action,job,eventName,ref,workflow # selectable (default: repo,message)
+        env:
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+        if: always()
 
   deploy:
    needs: push
@@ -102,3 +110,12 @@ jobs:
          service: explorer-indexer-service-${{ env.ENVIRONMENT }}
          cluster: sygma-explorer-${{ env.ENVIRONMENT }}
          wait-for-service-stability: true
+
+     - name: slack notify
+       uses: 8398a7/action-slack@v3
+       with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,job,eventName,ref,workflow # selectable (default: repo,message)
+       env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+       if: always()

--- a/.github/workflows/deploy_testnet_api.yml
+++ b/.github/workflows/deploy_testnet_api.yml
@@ -54,6 +54,15 @@ jobs:
           file: Dockerfile.api
           push: true
           tags: ${{ env.REGISTRY }}/${{ github.repository }}-api:${{ github.ref_name }}
+
+      - name: slack notify
+        uses: 8398a7/action-slack@v3
+        with:
+            status: ${{ job.status }}
+            fields: repo,message,commit,author,action,job,eventName,ref,workflow # selectable (default: repo,message)
+        env:
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+        if: always()
           
 
   deploy:
@@ -103,3 +112,12 @@ jobs:
          service: explorer-api-service-${{ env.ENVIRONMENT }}
          cluster: sygma-explorer-${{ env.ENVIRONMENT }}
          wait-for-service-stability: true
+
+     - name: slack notify
+       uses: 8398a7/action-slack@v3
+       with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,job,eventName,ref,workflow # selectable (default: repo,message)
+       env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+       if: always()


### PR DESCRIPTION

Pipeline Status Notification to be delivered to Slack Channel

## Description
I modified the GitHub Actions pipeline to send the status to a Slack channel. Thus, it reminds the user if the deployment/CI  build failed or was successful. 


## Related Issue Or Context
Related: #300

## How Has This Been Tested? Testing details.
See the [PREVIOUS INTEGRATION
](https://github.com/sygmaprotocol/sygma-relayer/pull/249#issue-2108952364)
## Types of changes
- [ ] New feature (non-breaking change which adds functionality)

