### PR TITLE
fix: check if deposit/fee already inserted

### DIFF
--- a/src/indexer/repository/deposit.ts
+++ b/src/indexer/repository/deposit.ts
@@ -11,5 +11,14 @@ class DepositRepository {
   public async insertDeposit(deposit: Deposit): Promise<void> {
     await this.deposit.create({ data: deposit })
   }
+
+  public async findDeposit(transferID: string): Promise<Deposit | null> {
+    return await this.deposit.findFirst({
+      where: {
+        transferId: transferID,
+      },
+    })
+  }
 }
+
 export default DepositRepository

--- a/src/indexer/repository/fee.ts
+++ b/src/indexer/repository/fee.ts
@@ -10,5 +10,13 @@ class FeeRepository {
   public async insertFee(fee: Fee): Promise<Fee> {
     return await this.fee.create({ data: fee })
   }
+
+  public async findFee(transferID: string): Promise<Fee | null> {
+    return await this.fee.findFirst({
+      where: {
+        transferId: transferID,
+      },
+    })
+  }
 }
 export default FeeRepository

--- a/src/indexer/utils/evm/index.ts
+++ b/src/indexer/utils/evm/index.ts
@@ -316,8 +316,16 @@ export async function saveDepositLogs(
     handlerResponse: decodedLog.handlerResponse,
     transferId: transfer.id,
   }
-  await depositRepository.insertDeposit(deposit)
-  await saveFee(decodedLog.fee, transfer.id, feeRepository)
+  const depositExists = await depositRepository.findDeposit(transfer.id)
+  const feeExists = await feeRepository.findFee(transfer.id)
+
+  if (!depositExists) {
+    await depositRepository.insertDeposit(deposit)
+  }
+
+  if (!feeExists) {
+    await saveFee(decodedLog.fee, transfer.id, feeRepository)
+  }
 }
 
 export async function saveFee(fee: FeeData, transferID: string, feeRepository: FeeRepository): Promise<void> {


### PR DESCRIPTION
check if deposit/fee already inserted
## Description
If the deposit for a transfer is already inserted, we shouldn't try to insert it again. This can happen if the processing of a block fails during fee insertion.
## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->

Closes: #<issue>

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [ ] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
