### PR TITLE
chore: Access Secrets based on environments segregate 

### DIFF
--- a/.github/workflows/deploy_mainnet.yml
+++ b/.github/workflows/deploy_mainnet.yml
@@ -22,7 +22,7 @@ jobs:
   deploy:
    name: deploy
    runs-on: ubuntu-latest
-   environment: mainnet
+   environment: mainnet 
    permissions:
      contents: read
      id-token: write
@@ -31,10 +31,10 @@ jobs:
      AWS_REGION: '${{ secrets.AWS_REGION }}'
      AWS_MAINNET: '${{ secrets.AWS_MAINNET }}'
    steps:
-    - name: Authorised User only
-      run: |
+     - name: Authorised User only
+       run: |
         if [[ ! " tcar121293 eedygreen MakMuftic akchainsafe mpetrun5 " =~ " ${{ github.actor }} " ]]; then 
-          echo "You are not authorized to deploy to mainnet."
+          echo "You are not authorized to deploy to mainnet!"
           exit 1
         fi
 

--- a/.github/workflows/deploy_mainnet.yml
+++ b/.github/workflows/deploy_mainnet.yml
@@ -22,7 +22,7 @@ jobs:
   deploy:
    name: deploy
    runs-on: ubuntu-latest
-   environment: testnet
+   environment: mainnet
    permissions:
      contents: read
      id-token: write
@@ -32,12 +32,12 @@ jobs:
      AWS_MAINNET: '${{ secrets.AWS_MAINNET }}'
    steps:
     - name: Authorised User only
-    run: |
-      if [[ ! " tcar121293 eedygreen MakMuftic akchainsafe mpetrun5 " =~ " ${{ github.actor }} " ]]; then 
-        echo "You are not authorized to deploy to mainnet."
-        exit 1
-      fi
-      
+      run: |
+        if [[ ! " tcar121293 eedygreen MakMuftic akchainsafe mpetrun5 " =~ " ${{ github.actor }} " ]]; then 
+          echo "You are not authorized to deploy to mainnet."
+          exit 1
+        fi
+
      - name: checkout ecs repo
        uses: actions/checkout@v4
        with:

--- a/.github/workflows/deploy_mainnet.yml
+++ b/.github/workflows/deploy_mainnet.yml
@@ -31,6 +31,13 @@ jobs:
      AWS_REGION: '${{ secrets.AWS_REGION }}'
      AWS_MAINNET: '${{ secrets.AWS_MAINNET }}'
    steps:
+    - name: Authorised User only
+    run: |
+      if [[ ! " tcar121293 eedygreen MakMuftic akchainsafe mpetrun5 " =~ " ${{ github.actor }} " ]]; then 
+        echo "You are not authorized to deploy to mainnet."
+        exit 1
+      fi
+      
      - name: checkout ecs repo
        uses: actions/checkout@v4
        with:

--- a/.github/workflows/deploy_mainnet.yml
+++ b/.github/workflows/deploy_mainnet.yml
@@ -11,10 +11,10 @@ on:
         description: deploy v2
         type: string
 
+run-name: Deploy Explorer-Indexer to Mainnet - ${{ inputs.release_tag }} by @${{ github.actor }}
+
 env:
-  AWS_REGION: '${{ secrets.AWS_REGION }}'
   ENVIRONMENT: MAINNET
-  AWS_MAINNET: '${{ secrets.AWS_MAINNET }}'
   REGISTRY: 'ghcr.io'
   VERSION: ${{ inputs.release_tag }}
 
@@ -22,12 +22,14 @@ jobs:
   deploy:
    name: deploy
    runs-on: ubuntu-latest
-
+   environment: testnet
    permissions:
      contents: read
      id-token: write
      actions: write
-
+   env:
+     AWS_REGION: '${{ secrets.AWS_REGION }}'
+     AWS_MAINNET: '${{ secrets.AWS_MAINNET }}'
    steps:
      - name: checkout ecs repo
        uses: actions/checkout@v4
@@ -46,8 +48,8 @@ jobs:
            awsAccountId=${{ env.AWS_MAINNET }}
            awsRegion=${{ env.AWS_REGION }}
            awsEnv=${{ env.ENVIRONMENT }}
-           DB_USERNAME=${{ secrets.MAIN_USERNAME }}
-           DB_PASSWORD=${{ secrets.MAIN_PASSWORD }}
+           DB_USERNAME=${{ secrets.DB_USERNAME }}
+           DB_PASSWORD=${{ secrets.DB_PASSWORD }}
            imageTag=${{ env.VERSION }}
 
      - name: Configure AWS Credentials
@@ -78,12 +80,14 @@ jobs:
   #  name: deploy v2
   
   #  runs-on: ubuntu-latest
-
+  #  environment: mainnet
   #  permissions:
   #    contents: read
   #    id-token: write
   #    actions: write
-
+  #  env:
+  #    AWS_REGION: '${{ secrets.AWS_REGION }}'
+  #    AWS_MAINNET: '${{ secrets.AWS_MAINNET }}'
   #  steps:
   #    - name: checkout ecs repo
   #      uses: actions/checkout@v4

--- a/.github/workflows/deploy_mainnet_api.yml
+++ b/.github/workflows/deploy_mainnet_api.yml
@@ -29,6 +29,13 @@ jobs:
      AWS_REGION: '${{ secrets.AWS_REGION }}'
      AWS_MAINNET: '${{ secrets.AWS_MAINNET }}'
    steps:
+    - name: Authorised User only
+    run: |
+      if [[ ! " tcar121293 eedygreen MakMuftic akchainsafe mpetrun5 " =~ " ${{ github.actor }} " ]]; then 
+        echo "You are not authorized to deploy to mainnet."
+        exit 1
+      fi
+
      - name: checkout ecs repo
        uses: actions/checkout@v4
        with:

--- a/.github/workflows/deploy_mainnet_api.yml
+++ b/.github/workflows/deploy_mainnet_api.yml
@@ -30,11 +30,11 @@ jobs:
      AWS_MAINNET: '${{ secrets.AWS_MAINNET }}'
    steps:
     - name: Authorised User only
-    run: |
-      if [[ ! " tcar121293 eedygreen MakMuftic akchainsafe mpetrun5 " =~ " ${{ github.actor }} " ]]; then 
-        echo "You are not authorized to deploy to mainnet."
-        exit 1
-      fi
+      run: |
+        if [[ ! " tcar121293 eedygreen MakMuftic akchainsafe mpetrun5 " =~ " ${{ github.actor }} " ]]; then 
+          echo "You are not authorized to deploy to mainnet."
+          exit 1
+        fi
 
      - name: checkout ecs repo
        uses: actions/checkout@v4

--- a/.github/workflows/deploy_mainnet_api.yml
+++ b/.github/workflows/deploy_mainnet_api.yml
@@ -9,10 +9,10 @@ on:
         default: 'stable' 
         type: string
 
+run-name: Deploy Explorer-API to Mainnet - ${{ inputs.release_tag }} by @${{ github.actor }}
+
 env:
-  AWS_REGION: '${{ secrets.AWS_REGION }}'
   ENVIRONMENT: MAINNET
-  AWS_MAINNET: '${{ secrets.AWS_MAINNET }}'
   REGISTRY: 'ghcr.io'
   VERSION: ${{ inputs.release_tag }}
 
@@ -20,12 +20,14 @@ jobs:
   deploy:
    name: deploy
    runs-on: ubuntu-latest
-
+   environment: mainnet
    permissions:
      contents: read
      id-token: write
      actions: write
-
+   env:
+     AWS_REGION: '${{ secrets.AWS_REGION }}'
+     AWS_MAINNET: '${{ secrets.AWS_MAINNET }}'
    steps:
      - name: checkout ecs repo
        uses: actions/checkout@v4
@@ -44,8 +46,8 @@ jobs:
            awsAccountId=${{ env.AWS_MAINNET }}
            awsRegion=${{ env.AWS_REGION }}
            awsEnv=${{ env.ENVIRONMENT }}
-           DB_USERNAME=${{ secrets.MAIN_USERNAME }}
-           DB_PASSWORD=${{ secrets.MAIN_PASSWORD }}
+           DB_USERNAME=${{ secrets.DB_USERNAME }}
+           DB_PASSWORD=${{ secrets.DB_PASSWORD }}
            imageTag=${{ env.VERSION }}
 
      - name: Configure AWS Credentials

--- a/.github/workflows/deploy_mainnet_api.yml
+++ b/.github/workflows/deploy_mainnet_api.yml
@@ -20,7 +20,7 @@ jobs:
   deploy:
    name: deploy
    runs-on: ubuntu-latest
-   environment: mainnet
+   environment: mainnet 
    permissions:
      contents: read
      id-token: write
@@ -29,10 +29,10 @@ jobs:
      AWS_REGION: '${{ secrets.AWS_REGION }}'
      AWS_MAINNET: '${{ secrets.AWS_MAINNET }}'
    steps:
-    - name: Authorised User only
-      run: |
+     - name: Authorised User only
+       run: |
         if [[ ! " tcar121293 eedygreen MakMuftic akchainsafe mpetrun5 " =~ " ${{ github.actor }} " ]]; then 
-          echo "You are not authorized to deploy to mainnet."
+          echo "You are not authorized to deploy to mainnet!"
           exit 1
         fi
 

--- a/.github/workflows/deploy_testnet.yml
+++ b/.github/workflows/deploy_testnet.yml
@@ -5,10 +5,10 @@ on:
     types:
       - published
 
+run-name: Deploy Explorer-Indexer to Testnet - ${{ inputs.release_tag }} by @${{ github.actor }}
+
 env:
-  AWS_REGION: '${{ secrets.AWS_REGION }}'
   ENVIRONMENT: TESTNET
-  AWS_TESTNET: '${{ secrets.AWS_ARN }}'
   REGISTRY: 'ghcr.io'
   TAG: 'stable'
   VERSION: ${{ github.event.release.tag_name }}
@@ -59,12 +59,14 @@ jobs:
    needs: push
    name: deploy
    runs-on: ubuntu-latest
-
+   environment: testnet
    permissions:
      contents: read
      id-token: write
      actions: write
-
+   env:
+     AWS_REGION: '${{ secrets.AWS_REGION }}'
+     AWS_TESTNET: '${{ secrets.AWS_ARN }}'
    steps:
      - name: checkout ecs repo
        uses: actions/checkout@v4

--- a/.github/workflows/deploy_testnet_api.yml
+++ b/.github/workflows/deploy_testnet_api.yml
@@ -5,10 +5,10 @@ on:
     types:
       - published
 
+run-name: Deploy Explorer-API to Testnet - ${{ inputs.release_tag }} by @${{ github.actor }}
+
 env:
-  AWS_REGION: '${{ secrets.AWS_REGION }}'
   ENVIRONMENT: TESTNET
-  AWS_TESTNET: '${{ secrets.AWS_ARN }}'
   REGISTRY: 'ghcr.io'
   TAG: 'stable'
   VERSION: ${{ github.event.release.tag_name }}
@@ -61,12 +61,14 @@ jobs:
    needs: push
    name: deploy
    runs-on: ubuntu-latest
-
+   environment: testnet
    permissions:
      contents: read
      id-token: write
      actions: write
-
+   env:
+     AWS_TESTNET: '${{ secrets.AWS_ARN }}'
+     AWS_REGION: '${{ secrets.AWS_REGION }}'
    steps:
      - name: checkout ecs repo
        uses: actions/checkout@v4


### PR DESCRIPTION

## Description
This is a separation of secrets from repository-wide to environment-specific. 
- Secrets can be accessed based on environments
- Review is required for deployment to Mainnet
- Added Deployment Authorisation To Mainnet

## Related Issue Or Context
Related: #[528](https://github.com/sygmaprotocol/devops/issues/528#issue-2539000686)


## How Has This Been Tested? Testing details.
Yes. for repos such as Sprinter, Sygma-relayer

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
